### PR TITLE
Cache admin main-menu

### DIFF
--- a/app/views/layouts/cms/application.html.erb
+++ b/app/views/layouts/cms/application.html.erb
@@ -7,7 +7,9 @@
 </head>
 <body>
 <nav id="main-nav">
-  <%= render 'layouts/cms/main_menu' %>
+  <% cache([current_user, 'admin-menu'], expires_in: 2.hours) do %>
+    <%= render 'layouts/cms/main_menu' %>
+  <% end %>
 </nav>
 <%= render 'cms/sites/flash' %>
 <section class="container center-column main-container bottom-form-btn clearfix">


### PR DESCRIPTION
In development, caching the main menu reduces each page load in admin by ~250ms. The cache key is scoped to current_user to maintain all functionality.
