### PR TITLE
Add ability for admins to correct duplicate positions within the sitemap

### DIFF
--- a/app/controllers/cms/section_nodes_controller.rb
+++ b/app/controllers/cms/section_nodes_controller.rb
@@ -59,6 +59,12 @@ module Cms
       }, status: 500
     end
 
+    def repair_sitemap
+      SectionNode.repair_sitemap
+      flash[:notice] = 'Repairing sitemap positions. Please refresh in a moment or two to see the results.'
+      redirect_to sitemap_path
+    end
+
     private
 
     # Retrieves all siblings that will need updating on success. This includes all siblings

--- a/app/models/cms/section_node.rb
+++ b/app/models/cms/section_node.rb
@@ -41,6 +41,11 @@ class Cms::SectionNode < ActiveRecord::Base
     def fetch_nodes
       includes(:node)
     end
+
+    def repair_sitemap
+      Rake::Task['sitemap:repair'].invoke
+    end
+    handle_asynchronously :repair_sitemap
   end
 
   # Return all section nodes which are not of the given type (i.e. class name)

--- a/app/views/cms/section_nodes/show.html.erb
+++ b/app/views/cms/section_nodes/show.html.erb
@@ -3,5 +3,17 @@
   <div id="sitemap" data-editable='<%= @sitemap_editable %>'>
     <%= render 'section_node', section_node: @sitemap, root: true %>
   </div>
+
+  <h3>Problems with Duplicate Positions?</h3>
+  <p>
+    If you're seeing pages with duplicate positions, click the 'Repair Sitemap Positioning' button below. Clicking
+    this button will traverse through the entire sitemap correcting any position issues it finds.
+  </p>
+  <p>
+    This should very rarely be necessary, but if you find you are having problems with duplicate
+    positions more often, please contact a developer for additional support.
+  </p>
+  <%= link_to 'Repair Sitemap Positioning', repair_sitemap_section_nodes_path, method: :put, class: 'btn btn-small btn-primary' %>
+  <br>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,9 @@ Cms::Engine.routes.draw do
     member do
       put :move_to_position
     end
+    collection do
+      put :repair_sitemap
+    end
   end
 
   resources :attachments, :only => [:show, :create, :destroy]

--- a/lib/tasks/sitemap.rake
+++ b/lib/tasks/sitemap.rake
@@ -1,0 +1,48 @@
+namespace :sitemap do
+  desc 'clean up and repair section node positioning'
+  task repair: :environment do
+    # Cms::Attachment nodes should always have a position of NULL
+    clear_attachment_positions
+
+    # Positions should be unique within a section. Loop through all roots (currently only one) and
+    # recursively repair the positions of any children.
+    Cms::SectionNode.roots.each do |root_node|
+      puts "[POS][REPAIR] Looking at #{Cms::Section.count} sections for positions needing repair..."
+      @updated = 0
+      repair_section_node_positions(root_node)
+      puts "Done. #{@updated} section nodes updated."
+    end
+  end
+
+  def clear_attachment_positions
+    attachment_nodes = Cms::SectionNode.where(node_type: 'Cms::Attachment').where.not(position: nil)
+    puts "[POS][REPAIR] Setting position to NULL for #{attachment_nodes.size} attachment(s)..."
+    attachment_nodes.update_all(position: nil)
+    puts 'Done'
+  end
+
+  def repair_section_node_positions(node)
+    # Find all positionable children within this node
+    children = node.children.not_of_type('Cms::Attachment')
+    puts "[POS][REPAIR]#{'  ' * node.depth}   Processing #{children.count} children for SectionNode ##{node.id} (#{node.node.name})..." if debug?
+
+    # Sort by current position and item name, then update child positions, starting with 0.
+    # Only update nodes where the position needs to change.
+    children.sort_by { |child| [child.position, child.node.name] }.each_with_index do |child, i|
+      next if child.position == i
+
+      puts "[POS][REPAIR]#{'  ' * child.depth} -> Updating postion from #{child.position} to #{i} for SectionNode ##{child.id} (#{child.node.name})" if debug?
+      child.update_column(:position, i)
+      @updated += 1
+    end
+
+    # Continue into any child sections
+    children.where(node_type: 'Cms::Section').each do |child_node|
+      repair_section_node_positions(child_node)
+    end
+  end
+
+  def debug?
+    ENV['LOG_LEVEL'] == 'debug'
+  end
+end


### PR DESCRIPTION
I was initially able to reproduce the sitemap issue that Amara and Andrew had reported, under certain circumstance. But once I ran the existing `sitemap:repair` task (moved over from CMS), I could no longer reproduce the issue.

Rather than dig into it further, I decided to give Marketing the ability to run the repair script themselves. I think it should be a very rare need. We haven't had this problem at all in the past ~10 months of this running in production and I'm unconvinced that the Ruby upgrade has changed how the underlying code works. If the problem persists, we can look into it further. For now, this gives them a quick way to correct the problem and get back to work.

**Note:** This is going into the `rails_4_2` branch which, I'm assuming, will get merged to master and released at some point.