### PR TITLE
Update travis to use postgres 15

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,18 @@ branches:
   - develop
 
 addons:
-  postgresql: '9.6' # Match ricksteves-prod
+  postgresql: '13'
+  apt:
+      packages:
+        - postgresql-13
 
 cache:
   bundler: true
 
 bundler_args: --without development
+
+before_install:
+  - postgres --version
 
 install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,9 @@ before_install:
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
+  - pg_lsclusters
   - sudo mkdir -p /usr/local/pgsql/data
+  - initdb -D /usr/local/pgsql/data
   - pg_ctl start -l postgres.log -D /usr/local/pgsql/data
   # give it a bit of time to run
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
-  - sudo apt install postgresql-15 postgresql-15-client -y
+  - sudo apt install postgresql=15 postgresql-client=15 -y
   
   # fix the postgres port number so that it is the normal default
   - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,8 @@ before_install:
   # fix the postgres port number so that it is the normal default
   - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
+  # fix postgres authentication
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   - sudo service postgresql restart
   # give it a bit of time to run

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,8 @@ branches:
 #       packages:
 #         - postgresql-14
 
-services:
-  - postgresql
+# services:
+#   - postgresql
 
 cache:
   bundler: true
@@ -27,7 +27,7 @@ before_install:
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
-  - sudo apt install postgresql postgresql-client -y
+  - sudo apt install postgresql-15 postgresql-15-client -y
   
   # fix the postgres port number so that it is the normal default
   - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,9 @@ bundler_args: --without development
 
 before_install:
   - pg_lsclusters
-  - sudo cat /etc/postgresql/*/main/pg_hba.conf
+  - sudo cat /etc/postgresql/*/main/postgresql.conf
   - sudo apt-get update
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
   - sudo service postgresql restart
   - sleep 1
   - postgres --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: bionic
+dist: xenial
 os: linux
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ cache:
 bundler_args: --without development
 
 before_install:
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo service postgresql restart
+  - sleep 1
   - postgres --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,11 @@ cache:
 bundler_args: --without development
 
 before_install:
+  - cat /etc/postgresql/*/main/pg_hba.conf
   - sudo apt-get update
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
+  - sudo service postgresql restart
+  - sleep 1
   - postgres --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ branches:
   - master
   - develop
 
+env:
+  global:
+   - PGUSER=postgres
+   - PGPORT=5432
+   - PGHOST=localhost
+
 addons:
   postgresql: '13'
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,10 @@ cache:
 bundler_args: --without development
 
 before_install:
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
-  - sudo service postgresql restart
-  - sleep 1
+  - sudo apt-get update
   - postgres --version
 
 install:
-  - sudo apt-get update
-  - sudo apt-get install imagemagick
   - psql -c 'create database browsercms_test;' -U postgres
   - gem install bundler:1.17.3
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
-  #- sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
+  - sudo sed -i -e 's/peer/trust/g' /etc/postgresql/15/main/pg_hba.conf
   #- sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,13 @@ bundler_args: --without development
 
 before_install:
   - sudo apt-get update
+  # fix the postgres port number so that it is the normal default
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
+  # restart postgres to pickup the config changes
   - sudo service postgresql restart
+  # give it a bit of time to run
   - sleep 1
+  # just check the version to make sure it is what we expect
   - postgres --version
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
   # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
+  - sudo cat /etc/postgresql/15/main/pg_hba.conf
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ before_install:
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
-  - sudo sed -i -e 's/peer/trust/g' /etc/postgresql/15/main/pg_hba.conf
+  - sudo sed -i -e 's/peer/trust/g' -e 's/scram-sha-256/trust/g' /etc/postgresql/15/main/pg_hba.conf
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ branches:
   - master
   - develop
 
-addons:
-  postgresql: 15
+# addons:
+#   postgresql: 15
 #   apt:
 #       packages:
 #         - postgresql-14
 
-services:
-  - postgresql
+# services:
+#   - postgresql
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - sudo apt install postgresql postgresql-client -y
   
   # fix the postgres port number so that it is the normal default
-  - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
+  # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ bundler_args: --without development
 
 before_install:
   - pg_lsclusters
-  - cat /etc/postgresql/*/main/pg_hba.conf
+  - sudo cat /etc/postgresql/*/main/pg_hba.conf
   - sudo apt-get update
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf
   - sudo service postgresql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  - su postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  # - su postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PGHOST=localhost
     - PGPORT=5432
     - PGUSER=postgres
-    - PGPASSWORD=
+    - PGPASSWORD=admin
 
 cache:
   bundler: true
@@ -42,7 +42,7 @@ before_install:
   # fix postgres authentication
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
   - sudo sed -i -e 's/peer/trust/g' /etc/postgresql/15/main/pg_hba.conf
-  #- sudo cat /etc/postgresql/15/main/pg_hba.conf
+  - sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
@@ -56,7 +56,6 @@ before_install:
   - pg_lsclusters
 
 install:
-  - echo $PGHOST:$PGPORT:$PGUSER:$PGPASSWORD
   - psql -c 'create database browsercms_test;' -U postgres
   - gem install bundler:1.17.3
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  - pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  - sudo pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: jammy
+dist: focal
 os: linux
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - PGHOST=localhost
     - PGPORT=5432
     - PGUSER=postgres
+    - PGPASSWORD=
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
+  - which pg_ctl
   - sudo pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
-  - sudo apt install postgresql=15 postgresql-client=15 -y
+  - sudo apt install postgresql postgresql-client -y
   
   # fix the postgres port number so that it is the normal default
   - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ before_install:
   # fix postgres authentication
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
-  - sudo service postgresql restart
+  # - sudo service postgresql restart
+  - pg_ctl start -D /usr/local/var/postgres
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PGHOST=localhost
     - PGPORT=5432
     - PGUSER=postgres
-    - PGPASSWORD=
+    - PGPASSWORD=''
 
 cache:
   bundler: true
@@ -54,6 +54,7 @@ before_install:
   - pg_lsclusters
 
 install:
+  - echo pg pass:$PGPASSWORD
   - psql -c 'create database browsercms_test;' -U postgres
   - gem install bundler:1.17.3
   - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ branches:
   - develop
 
 addons:
-  postgresql: '15'
+  postgresql: 14
   apt:
       packages:
-        - postgresql-15
+        - postgresql-14
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  - sudo /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  - su postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,17 @@ before_install:
   
   # fix the postgres port number so that it is the normal default
   # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
-  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
+  # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
   - pg_lsclusters
-  - sudo mkdir -p /usr/local/pgsql/data
-  - initdb -D /usr/local/pgsql/data
-  - pg_ctl start -l postgres.log -D /usr/local/pgsql/data
+  #- sudo mkdir -p /usr/local/pgsql/data
+  #- sudo initdb -D /usr/local/pgsql/data
+  #- pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  - pg_ctl restart
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
-  - pg_ctl start
+  - pg_ctl start -l postgres.log -D /usr/local/pgsql/data
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,6 @@ branches:
   - master
   - develop
 
-env:
-  global:
-   - PGUSER=postgres
-   - PGPORT=5432
-   - PGHOST=localhost
-
 addons:
   postgresql: '13'
   apt:
@@ -25,8 +19,6 @@ cache:
 bundler_args: --without development
 
 before_install:
-  - pg_lsclusters
-  - sudo cat /etc/postgresql/*/main/postgresql.conf
   - sudo apt-get update
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
   - sudo service postgresql restart

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
-  - mkdir -p /usr/local/var/postgres
+  - sudo mkdir -p /usr/local/var/postgres
   - pg_ctl start -D /usr/local/var/postgres
   # give it a bit of time to run
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
+  - sudo mkdir -p /usr/local/pgsql/data
   - pg_ctl start -l postgres.log -D /usr/local/pgsql/data
   # give it a bit of time to run
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect
-  - pg_lscluster
+  - pg_lsclusters
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,12 @@ addons:
 services:
   - postgresql
 
+env:
+  global:
+    - PGHOST=localhost
+    - PGPORT=5432
+    - PGUSER=postgres
+
 cache:
   bundler: true
 
@@ -40,7 +46,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  # - su postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  - sudo -u postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PGHOST=localhost
     - PGPORT=5432
     - PGUSER=postgres
-    - PGPASSWORD=postgres
+    - PGPASSWORD=
 
 cache:
   bundler: true
@@ -41,8 +41,8 @@ before_install:
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo cat /etc/postgresql/15/main/pg_hba.conf
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
-  - sudo cat /etc/postgresql/15/main/pg_hba.conf
+  #- sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
+  #- sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  #- pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
-  - pg_ctl restart
+  - pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ cache:
 bundler_args: --without development
 
 before_install:
+  - pg_lsclusters
+
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,8 @@ before_install:
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
+  # manually start new postgres versions in old distros
+  - mkdir -p /usr/local/var/postgres
   - pg_ctl start -D /usr/local/var/postgres
   # give it a bit of time to run
   - sleep 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: focal
+dist: bionic
 os: linux
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,11 @@ branches:
   - master
   - develop
 
-# addons:
-#   postgresql: 14
-#   apt:
-#       packages:
-#         - postgresql-14
-
-# services:
-#   - postgresql
+addons:
+  postgresql: '13'
+  apt:
+      packages:
+        - postgresql-13
 
 cache:
   bundler: true
@@ -22,24 +19,15 @@ cache:
 bundler_args: --without development
 
 before_install:
-  - pg_lsclusters
-
-  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-  - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
-  - sudo apt install postgresql postgresql-client -y
-  
   # fix the postgres port number so that it is the normal default
-  # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
-  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
-  # fix postgres authentication
-  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
   # restart postgres to pickup the config changes
   - sudo service postgresql restart
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect
-  - pg_lsclusters
+  - postgres --version
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
   - sudo apt install postgresql postgresql-client -y
   
   # fix the postgres port number so that it is the normal default
-  # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
+  - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # restart postgres to pickup the config changes
   - sudo service postgresql restart
   # give it a bit of time to run

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ before_install:
   - pg_lsclusters
   #- sudo mkdir -p /usr/local/pgsql/data
   #- sudo initdb -D /usr/local/pgsql/data
-  - which pg_ctl
-  - sudo pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
+  - sudo /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: bionic
+dist: focal
 os: linux
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - PGHOST=localhost
     - PGPORT=5432
     - PGUSER=postgres
-    - PGPASSWORD=''
+    - PGPASSWORD=postgres
 
 cache:
   bundler: true
@@ -41,6 +41,7 @@ before_install:
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
+  - sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
@@ -52,7 +53,6 @@ before_install:
   - sleep 1
   # just check the version to make sure it is what we expect
   - pg_lsclusters
-  - createuser -s postgres
 
 install:
   - echo $PGHOST:$PGPORT:$PGUSER:$PGPASSWORD

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,7 @@ before_install:
   # restart postgres to pickup the config changes
   # - sudo service postgresql restart
   # manually start new postgres versions in old distros
-  - sudo mkdir -p /usr/local/var/postgres
-  - pg_ctl start -D /usr/local/var/postgres
+  - pg_ctl start
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect
-  - postgres --version
+  - pg_lscluster
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ branches:
   - master
   - develop
 
-# addons:
-#   postgresql: 14
+addons:
+  postgresql: 15
 #   apt:
 #       packages:
 #         - postgresql-14
 
-# services:
-#   - postgresql
+services:
+  - postgresql
 
 cache:
   bundler: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ cache:
 bundler_args: --without development
 
 before_install:
-  # - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-  # - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
-  # - sudo apt-get update
-  # - sudo apt install postgresql postgresql-client -y
+  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
+  - sudo apt-get update
+  - sudo apt install postgresql postgresql-client -y
   
   # fix the postgres port number so that it is the normal default
   # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ branches:
   - develop
 
 addons:
-  postgresql: '13'
+  postgresql: '15'
   apt:
       packages:
-        - postgresql-13
+        - postgresql-15
 
 cache:
   bundler: true
@@ -21,7 +21,7 @@ bundler_args: --without development
 before_install:
   - sudo apt-get update
   # fix the postgres port number so that it is the normal default
-  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
+  # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # restart postgres to pickup the config changes
   - sudo service postgresql restart
   # give it a bit of time to run

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,54 +7,28 @@ branches:
   - master
   - develop
 
-# addons:
-#   postgresql: 15
-#   apt:
-#       packages:
-#         - postgresql-14
-
-# services:
-#   - postgresql
-
-env:
-  global:
-    - PGHOST=localhost
-    - PGPORT=5432
-    - PGUSER=postgres
-    - PGPASSWORD=admin
-
 cache:
   bundler: true
 
 bundler_args: --without development
 
 before_install:
-  - pg_lsclusters
-
+  # add postgres 15 repos
   - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
   - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
+  # install postgres 15
   - sudo apt install postgresql postgresql-client -y
-  
-  # fix the postgres port number so that it is the normal default
-  # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
+  # fix the postgres port number so that it is 5432
   - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
-  # fix postgres authentication
-  - sudo cat /etc/postgresql/15/main/pg_hba.conf
+  # allow all postgres connections without a password - NOT SAFE FOR PRODUCTION
   - sudo sed -i -e 's/peer/trust/g' -e 's/scram-sha-256/trust/g' /etc/postgresql/15/main/pg_hba.conf
-  - sudo cat /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
-  # - sudo service postgresql restart
-  # manually start new postgres versions in old distros
-  - pg_lsclusters
-  #- sudo mkdir -p /usr/local/pgsql/data
-  #- sudo initdb -D /usr/local/pgsql/data
   - sudo -u postgres /usr/lib/postgresql/15/bin/pg_ctl restart -l /var/log/postgresql/postgresql-15-main.log -D /var/lib/postgresql/15/main
   # give it a bit of time to run
   - sleep 1
-  # just check the version to make sure it is what we expect
+  # check the state of the installed postgres's
   - pg_lsclusters
-  - sudo cat /var/log/postgresql/postgresql-15-main.log
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ cache:
 bundler_args: --without development
 
 before_install:
+  - pg_lsclusters
   - cat /etc/postgresql/*/main/pg_hba.conf
   - sudo apt-get update
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/*/main/pg_hba.conf

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: bionic
 os: linux
 
 branches:
@@ -7,11 +7,14 @@ branches:
   - master
   - develop
 
-addons:
-  postgresql: '13'
-  apt:
-      packages:
-        - postgresql-13
+# addons:
+#   postgresql: 14
+#   apt:
+#       packages:
+#         - postgresql-14
+
+# services:
+#   - postgresql
 
 cache:
   bundler: true
@@ -19,15 +22,24 @@ cache:
 bundler_args: --without development
 
 before_install:
+  - pg_lsclusters
+
+  - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
   - sudo apt-get update
+  - sudo apt install postgresql postgresql-client -y
+  
   # fix the postgres port number so that it is the normal default
-  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/13/main/postgresql.conf
+  # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
+  # fix postgres authentication
+  - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes
   - sudo service postgresql restart
   # give it a bit of time to run
   - sleep 1
   # just check the version to make sure it is what we expect
-  - postgres --version
+  - pg_lsclusters
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ before_install:
   - sleep 1
   # just check the version to make sure it is what we expect
   - pg_lsclusters
+  - sudo cat /var/log/postgresql/postgresql-15-main.log
 
 install:
   - psql -c 'create database browsercms_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_install:
   
   # fix the postgres port number so that it is the normal default
   # - sudo sed -i 's/port = 5432/port = 5433/' /etc/postgresql/13/main/postgresql.conf
-  # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
+  - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # fix postgres authentication
   - sudo sed -i -e '/local.*peer/s/postgres/all/' -e 's/peer\|md5/trust/g' /etc/postgresql/15/main/pg_hba.conf
   # restart postgres to pickup the config changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
-dist: xenial
+dist: jammy
 os: linux
 
 branches:
@@ -7,11 +7,14 @@ branches:
   - master
   - develop
 
-addons:
-  postgresql: 14
-  apt:
-      packages:
-        - postgresql-14
+# addons:
+#   postgresql: 14
+#   apt:
+#       packages:
+#         - postgresql-14
+
+services:
+  - postgresql
 
 cache:
   bundler: true
@@ -19,7 +22,11 @@ cache:
 bundler_args: --without development
 
 before_install:
-  - sudo apt-get update
+  # - sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+  # - wget -qO- https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo tee /etc/apt/trusted.gpg.d/pgdg.asc &>/dev/null
+  # - sudo apt-get update
+  # - sudo apt install postgresql postgresql-client -y
+  
   # fix the postgres port number so that it is the normal default
   # - sudo sed -i 's/port = 5433/port = 5432/' /etc/postgresql/15/main/postgresql.conf
   # restart postgres to pickup the config changes

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,9 +52,10 @@ before_install:
   - sleep 1
   # just check the version to make sure it is what we expect
   - pg_lsclusters
+  - createuser -s postgres
 
 install:
-  - echo pg pass:$PGPASSWORD
+  - echo $PGHOST:$PGPORT:$PGUSER:$PGPASSWORD
   - psql -c 'create database browsercms_test;' -U postgres
   - gem install bundler:1.17.3
   - bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.7.8'
 gemspec
 # gem 'query_reviewer' # Enable for performance tuning
 
-gem 'puma'
+gem 'puma', '~> 4'
 gem 'railties', '~> 4.2'
 # Uncomment to confirm that older versions work (for compaitiblity with Spree 2.2.4/bcms_spree)
 # gem 'paperclip', '~> 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -207,6 +207,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    nio4r (2.5.9)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -228,7 +229,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    puma (3.6.0)
+    puma (4.3.12)
+      nio4r (~> 2.0)
     racc (1.7.1)
     rack (1.6.13)
     rack-test (0.6.3)
@@ -346,7 +348,7 @@ DEPENDENCIES
   pg
   poltergeist
   pry
-  puma
+  puma (~> 4)
   railties (~> 4.2)
   rake
   ruby-prof


### PR DESCRIPTION
This PR installs postgresql 15 in Travis. Travis doesnt explicitly support v15, and v15 doesnt like the older distros that are available. Of course Puma 3 doesnt build with the newer distros, so that needed to be upgraded to v4.

Everything is working now!